### PR TITLE
Changes to accomodate build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,24 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 PROJECT(SGP4)
 
+set (CMAKE_CXX_STANDARD 11)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+
+if(DEFINED MSVC_VERSION)
+    if (MSVC_VERSION GREATER_EQUAL "1900")
+        include(CheckCXXCompilerFlag)
+        CHECK_CXX_COMPILER_FLAG("/std:c++latest" _cpp_latest_flag_supported)
+        if (_cpp_latest_flag_supported)
+            add_compile_options("/std:c++latest")
+        endif()
+    endif()
+endif()
+
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wshadow")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-long-long")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcast-align")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-conversion")
 
 include_directories(libsgp4)
 
@@ -19,4 +27,4 @@ add_subdirectory(sattrack)
 add_subdirectory(runtest)
 add_subdirectory(passpredict)
 
-file(COPY SGP4-VER.TLE DESTINATION ${PROJECT_BINARY_DIR})
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/SGP4-VER.TLE DESTINATION ${PROJECT_BINARY_DIR})

--- a/libsgp4/CMakeLists.txt
+++ b/libsgp4/CMakeLists.txt
@@ -32,10 +32,9 @@ set(SRCS
      TleException.h
      Tle.h
      Util.h
-     Vector.h
-     )
+     Vector.h)
 
 add_library(sgp4 STATIC ${SRCS} ${INCS})
 add_library(sgp4s SHARED ${SRCS} ${INCS})
-install( TARGETS sgp4s LIBRARY DESTINATION lib )
-install( FILES ${INCS} DESTINATION include/SGP4 )
+install(TARGETS sgp4s DESTINATION lib)
+install( FILES ${INCS} DESTINATION include/SGP4)

--- a/libsgp4/DateTime.h
+++ b/libsgp4/DateTime.h
@@ -22,6 +22,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdint.h>
+#include <algorithm>
 #include "TimeSpan.h"
 #include "Util.h"
 
@@ -141,27 +142,19 @@ public:
     static DateTime Now(bool microseconds = false)
     {
         DateTime dt;
-        struct timespec ts;
-
-        if (clock_gettime(CLOCK_REALTIME, &ts) == 0)
-        {
-            if (microseconds)
-            {
-                dt = DateTime(UnixEpoch
-                    + ts.tv_sec * TicksPerSecond
-                    + ts.tv_nsec / 1000LL * TicksPerMicrosecond);
-            }
-            else
-            {
-                dt = DateTime(UnixEpoch
-                    + ts.tv_sec * TicksPerSecond);
-            }
-        }
+        Util::UnixTimestamp ts = Util::CurrentTime();
+        
+        if (microseconds)
+	{
+	    dt = DateTime(UnixEpoch
+	                  + ts.seconds * TicksPerSecond
+	                  + ts.nanoseconds / 1000LL * TicksPerMicrosecond);
+	}
         else
-        {
-            throw 1;
-        }
-
+	{
+	    dt = DateTime(UnixEpoch
+	                  + ts.nanoseconds * TicksPerSecond);
+	}
         return dt;
     }
 

--- a/libsgp4/Util.h
+++ b/libsgp4/Util.h
@@ -18,93 +18,173 @@
 #ifndef UTIL_H_
 #define UTIL_H_
 
+#ifdef _WIN32
+#define NOMINMAX
+#include <Windows.h>
+#endif
+
 #include "Globals.h"
 
+#include <iostream>
+#include <mutex>
+#include <algorithm>
+#include <cctype>
+#include <ctime>
+#include <atomic>
 #include <sstream>
 
 namespace Util
 {
-    template
-    <typename T>
-    bool FromString(const std::string& str, T& val)
-    {
-        std::stringstream ss(str);
-        return !(ss >> val).fail();
-    }
 
-    /*
-     * always positive result
-     * Mod(-3,4)= 1   fmod(-3,4)= -3
-     */
-    inline double Mod(const double x, const double y)
-    {
-        if (y == 0.0)
-        {
-            return x;
-        }
+	template
+		<typename T>
+		bool FromString(const std::string& str, T& val)
+	{
+		std::stringstream ss(str);
+		return !(ss >> val).fail();
+	}
 
-        return x - y * floor(x / y);
-    }
+	/*
+	 * always positive result
+	 * Mod(-3,4)= 1   fmod(-3,4)= -3
+	 */
+	inline double Mod(const double x, const double y)
+	{
+		if (y == 0.0)
+		{
+			return x;
+		}
 
-    inline double WrapNegPosPI(const double a)
-    {
-        return Mod(a + kPI, kTWOPI) - kPI;
-    }
-    
-    inline double WrapTwoPI(const double a)
-    {
-        return Mod(a, kTWOPI);
-    }
+		return x - y * floor(x / y);
+	}
 
-    inline double WrapNegPos180(const double a)
-    {
-        return Mod(a + 180.0, 360.0) - 180.0;
-    }
+	inline double WrapNegPosPI(const double a)
+	{
+		return Mod(a + kPI, kTWOPI) - kPI;
+	}
 
-    inline double Wrap360(const double a)
-    {
-        return Mod(a, 360.0);
-    }
+	inline double WrapTwoPI(const double a)
+	{
+		return Mod(a, kTWOPI);
+	}
 
-    inline double DegreesToRadians(const double degrees)
-    {
-        return degrees * kPI / 180.0;
-    }
+	inline double WrapNegPos180(const double a)
+	{
+		return Mod(a + 180.0, 360.0) - 180.0;
+	}
 
-    inline double RadiansToDegrees(const double radians)
-    {
-        return radians * 180.0 / kPI;
-    }
+	inline double Wrap360(const double a)
+	{
+		return Mod(a, 360.0);
+	}
 
-    inline double AcTan(const double sinx, const double cosx)
-    {
-        if (cosx == 0.0)
-        {
-            if (sinx > 0.0)
-            {
-                return kPI / 2.0;
-            }
-            else
-            {
-                return 3.0 * kPI / 2.0;
-            }
-        }
-        else
-        {
-            if (cosx > 0.0)
-            {
-                return atan(sinx / cosx);
-            }
-            else
-            {
-                return kPI + atan(sinx / cosx);
-            }
-        }
-    }
-    
-    void TrimLeft(std::string& s);
-    void TrimRight(std::string& s);
-    void Trim(std::string& s);
+	inline double DegreesToRadians(const double degrees)
+	{
+		return degrees * kPI / 180.0;
+	}
+
+	inline double RadiansToDegrees(const double radians)
+	{
+		return radians * 180.0 / kPI;
+	}
+
+	inline double AcTan(const double sinx, const double cosx)
+	{
+		if (cosx == 0.0)
+		{
+			if (sinx > 0.0)
+			{
+				return kPI / 2.0;
+			}
+			else
+			{
+				return 3.0 * kPI / 2.0;
+			}
+		}
+		else
+		{
+			if (cosx > 0.0)
+			{
+				return atan(sinx / cosx);
+			}
+			else
+			{
+				return kPI + atan(sinx / cosx);
+			}
+		}
+	}
+
+	// time since unix epoch
+	struct UnixTimestamp
+	{
+		int64_t seconds;
+		int64_t nanoseconds;
+	};
+
+    #ifdef _WIN32
+	    typedef void (WINAPI *FuncT) (LPFILETIME lpSystemTimeAsFileTime);
+
+	    class WindowsUtcTimeSource
+	    {
+	    public:
+		    inline bool IsPrecise() { return m_isPrecise; };
+
+		    static WindowsUtcTimeSource* Instance();
+		    UnixTimestamp GetUtcTime();
+
+	    private:
+		    static std::atomic<WindowsUtcTimeSource*> m_instance;
+        static std::mutex m_mutex;
+		    FuncT m_getUtcTimeFunc;
+		    bool m_isPrecise;
+
+		    WindowsUtcTimeSource();
+		    WindowsUtcTimeSource(const WindowsUtcTimeSource&) = delete;
+		    WindowsUtcTimeSource& operator=(WindowsUtcTimeSource const&) = delete;
+	    };
+    #endif
+
+	inline UnixTimestamp CurrentTime()
+	{
+		UnixTimestamp stamp;
+    		#ifdef _WIN32
+                	stamp = WindowsUtcTimeSource::Instance()->GetUtcTime();		
+        	#else
+      		  	struct timespec ts;
+        		if (clock_gettime(CLOCK_REALTIME, &ts) == 0)
+			{
+				stamp.seconds = ts.tv_sec;
+				stamp.nanoseconds = ts.tv_nsec;
+			}
+			else
+			{
+				throw 1;
+			}	    
+        #endif
+		return stamp;
+	}
+
+	static inline void TrimLeft(std::string &s)
+	{
+    		s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](int ch)
+		{
+	    		return !std::isspace(ch);	
+		}));
+	}
+
+	static inline void TrimRight(std::string &s) {
+		s.erase(std::find_if(s.rbegin(), s.rend(), [](int ch)
+		{
+			return !std::isspace(ch);
+		}).base(), s.end());
+	}
+
+	static inline void Trim(std::string &s)
+	{
+		TrimLeft(s);
+		TrimRight(s);
+	}
+
 }
 
 #endif

--- a/passpredict/CMakeLists.txt
+++ b/passpredict/CMakeLists.txt
@@ -4,5 +4,4 @@ set(SRCS
 add_executable(passpredict
     ${SRCS})
 target_link_libraries(passpredict
-    sgp4
-    rt)
+    sgp4)

--- a/runtest/CMakeLists.txt
+++ b/runtest/CMakeLists.txt
@@ -4,5 +4,4 @@ set(SRCS
 add_executable(runtest
     ${SRCS})
 target_link_libraries(runtest
-    sgp4
-    rt)
+    sgp4)

--- a/runtest/runtest.cc
+++ b/runtest/runtest.cc
@@ -273,7 +273,7 @@ void RunTest(const char* infile)
 
 int main()
 {
-    const char* file_name = "SGP4-VER.TLE";
+    const char* file_name = "../SGP4-VER.TLE";
 
     RunTest(file_name);
 

--- a/sattrack/CMakeLists.txt
+++ b/sattrack/CMakeLists.txt
@@ -4,5 +4,4 @@ set(SRCS
 add_executable(sattrack
     ${SRCS})
 target_link_libraries(sattrack
-    sgp4
-    rt)
+    sgp4)


### PR DESCRIPTION
- removed librt dependency
- specify C++11 as standard
- remove some compiler flags
- added WindowsUtcTimeSource singleton class (determines if GetSystemTimePreciseAsFileTime is available)
- updated DateTime::Now to use WindowsUtcTimeSource if compiling on Windows